### PR TITLE
Customize path prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,32 @@ app.use(
 );
 ```
 
+
+Serving files from a different directory
+---------------
+It is possible to serve files from a directory that doesn't math your request path.
+
+
+For example:
+| Static Dir          | Request URI       |
+|---------------------|-------------------|
+| `/home/app/static`  | `/assets/app.css` |
+
+You would configure it like this:
+```typescript
+import { Application } from '@curveball/core';
+import serveFiles from '@curveball/static';
+
+const app = new Application();
+app.use(
+    serveFiles({
+        // Absolute path to assets directory
+        staticDir: `${process.cwd()}/static`,
+        pathPrefix: '/assets',
+    })
+);
+```
+
 API
 ---
 
@@ -32,4 +58,7 @@ The default export for this package is the `serveFiles` function. When called, t
 function returns a middleware. It accepts a dictionary of configuration options.
 
 ### Options
-- `staticDir` Absolute path to assets directory
+- `staticDir`: Absolute path to assets directory. Assets cannot be served above this directory
+- `pathPrefix`: Request path to match if it differs from the static directory
+
+[1]: https://github.com/curveball/

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import { Options, serveFiles } from './serve';
+import { serveFiles } from './serve';
+import { Options} from './types';
 
 export default serveFiles;
 export {

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -2,13 +2,10 @@ import fs from 'fs';
 
 import { Context, Middleware } from '@curveball/core';
 
+import { Options } from './types';
 import { doesMatchRoute, validateFile, getMimeType } from './util';
 
 const fsPromises = fs.promises;
-
-export type Options = {
-  staticDir: string,
-}
 
 export function serveFiles(options: Options): Middleware {
   return async (ctx: Context, next) => {
@@ -24,13 +21,13 @@ export async function serve(options: Options, ctx: Context): Promise<boolean> {
   const { staticDir } = options;
   const { path: requestPath } = ctx.request;
 
-  if (!doesMatchRoute(staticDir, requestPath)) {
+  if (!doesMatchRoute(options, requestPath)) {
     return false;
   }
 
-  await validateFile(staticDir, requestPath);
+  const filePath = `${staticDir}/${requestPath.split('/').slice(2).join('/')}`;
 
-  const filePath = staticDir + '/' + requestPath.split('/').slice(2).join('/');
+  await validateFile(filePath, staticDir);
 
   ctx.status = 200;
   ctx.response.body = await fsPromises.readFile(filePath);

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import { Context, Middleware } from '@curveball/core';
 
 import { Options } from './types';
-import { doesMatchRoute, validateFile, getMimeType } from './util';
+import { doesMatchRoute, getFilePath, getMimeType, validateFile } from './util';
 
 const fsPromises = fs.promises;
 
@@ -25,7 +25,7 @@ export async function serve(options: Options, ctx: Context): Promise<boolean> {
     return false;
   }
 
-  const filePath = `${staticDir}/${requestPath.split('/').slice(2).join('/')}`;
+  const filePath = getFilePath(options, requestPath);
 
   await validateFile(filePath, staticDir);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+export type Options = {
+  staticDir: string,
+  pathPrefix?: string,
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,12 +8,16 @@ import { Options } from './types';
 
 const fsPromises = fs.promises;
 
-export function doesMatchRoute(options: Options, requestPath: string): boolean {
-  const staticFolder = options.pathPrefix ? options.pathPrefix.replace('/', '') : options.staticDir.split('/').pop();
-  const pathFolder = requestPath.split('/')[1];
+export function getStaticPrefix(options: Options): string {
+  return options.pathPrefix ? options.pathPrefix : `/${options.staticDir.split('/').pop()}`;
+}
 
-  // Verify that the static asset asked for in the request matches the static folder
-  return staticFolder === pathFolder;
+export function doesMatchRoute(options: Options, requestPath: string): boolean {
+  return requestPath.startsWith(getStaticPrefix(options));
+}
+
+export function getFilePath(options: Options, requestPath: string): string {
+  return `${options.staticDir}${requestPath}`.replace(getStaticPrefix(options), '');
 }
 
 export async function validateFile(filePath: string, staticDir: string): Promise<void> {

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,22 +4,19 @@ import path from 'path';
 import { BadRequest, NotFound } from '@curveball/http-errors';
 import mime from 'mime-types';
 
+import { Options } from './types';
+
 const fsPromises = fs.promises;
 
-export function doesMatchRoute(staticDir: string, requestPath: string): boolean {
-  const staticFolder = staticDir.split('/').pop();
+export function doesMatchRoute(options: Options, requestPath: string): boolean {
+  const staticFolder = options.pathPrefix ? options.pathPrefix.replace('/', '') : options.staticDir.split('/').pop();
   const pathFolder = requestPath.split('/')[1];
 
-  // The last folder in the static path and the first folder in the request
-  // path need to be the same for this middleware to match.
-  // Ex: staticDir = /home/app/static & requestPath = /static/app.css
-  // This is so every single request is not evaluated as if it's a file
+  // Verify that the static asset asked for in the request matches the static folder
   return staticFolder === pathFolder;
 }
 
-export async function validateFile(staticDir: string, requestPath: string): Promise<void> {
-  const filePath = `${staticDir}/${requestPath.split('/').slice(2).join('/')}`;
-
+export async function validateFile(filePath: string, staticDir: string): Promise<void> {
   // Only serve files that are within the static directory
   const relativePath = path.relative(staticDir, filePath);
   if (relativePath.startsWith('../')) {

--- a/test/util.ts
+++ b/test/util.ts
@@ -2,10 +2,30 @@ import { BadRequest, NotFound } from '@curveball/http-errors';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
-import { doesMatchRoute, validateFile, getMimeType } from '../src/util';
+import { doesMatchRoute, getFilePath, getMimeType, getStaticPrefix, validateFile } from '../src/util';
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
+
+describe('getStaticPrefix', () => {
+  const staticDir = `${process.cwd()}/test/assets`;
+
+  it('should get prefix from static directory', () => {
+    expect(getStaticPrefix({ staticDir })).to.equal('/assets');
+  });
+
+  it('should get prefix from option', () => {
+    expect(getStaticPrefix({ staticDir, pathPrefix: '/static' })).to.equal('/static');
+  });
+});
+
+describe('getFilePath', () => {
+  const staticDir = `${process.cwd()}/test/assets`;
+
+  it('should return path', () => {
+    expect(getFilePath({ staticDir }, '/assets/test.txt')).to.equal(`${staticDir}/test.txt`);
+  });
+});
 
 describe('doesMatchRoute', () => {
   const staticDir = `${process.cwd()}/test/assets`;
@@ -26,6 +46,7 @@ describe('doesMatchRoute', () => {
 
   it('should match routes with pathPrefix', () => {
     expect(doesMatchRoute({ staticDir, pathPrefix: '/static' }, '/static/test.txt')).to.be.true;
+    expect(doesMatchRoute({ staticDir, pathPrefix: '/static/more' }, '/static/more/test.txt')).to.be.true;
   });
 
   it('should match not routes with pathPrefix', () => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -11,17 +11,25 @@ describe('doesMatchRoute', () => {
   const staticDir = `${process.cwd()}/test/assets`;
 
   it('should match routes', () => {
-    expect(doesMatchRoute(staticDir, '/assets/test.txt')).to.be.true;
-    expect(doesMatchRoute(staticDir, '/assets/deeper/test.txt')).to.be.true;
-    expect(doesMatchRoute(staticDir, '/assets')).to.be.true;
-    expect(doesMatchRoute(staticDir, '/assets/deeper/../test.txt')).to.be.true;
+    expect(doesMatchRoute({ staticDir }, '/assets/test.txt')).to.be.true;
+    expect(doesMatchRoute({ staticDir }, '/assets/deeper/test.txt')).to.be.true;
+    expect(doesMatchRoute({ staticDir }, '/assets')).to.be.true;
+    expect(doesMatchRoute({ staticDir }, '/assets/deeper/../test.txt')).to.be.true;
   });
 
   it('should not match routes', () => {
     // Beginning folder of path is wrong
-    expect(doesMatchRoute(staticDir, '/static/test.txt')).to.be.false;
+    expect(doesMatchRoute({ staticDir }, '/static/test.txt')).to.be.false;
     // Access incorrect directory
-    expect(doesMatchRoute(staticDir, '/')).to.be.false;
+    expect(doesMatchRoute({ staticDir }, '/')).to.be.false;
+  });
+
+  it('should match routes with pathPrefix', () => {
+    expect(doesMatchRoute({ staticDir, pathPrefix: '/static' }, '/static/test.txt')).to.be.true;
+  });
+
+  it('should match not routes with pathPrefix', () => {
+    expect(doesMatchRoute({ staticDir, pathPrefix: '/static' }, '/assets/test.txt')).to.be.false;
   });
 });
 
@@ -29,24 +37,22 @@ describe('validateFile', () => {
   const staticDir = `${process.cwd()}/test/assets`;
 
   it('should validate file', async () => {
-    await expect(validateFile(staticDir, '/assets/test.txt')).to.be.fulfilled;
-    await expect(validateFile(staticDir, '/assets/nested/test.txt')).to.be.fulfilled;
-    await expect(validateFile(staticDir, '/assets/nested/../test.txt')).to.be.fulfilled;
+    await expect(validateFile(`${staticDir}/test.txt`, staticDir)).to.be.fulfilled;
+    await expect(validateFile(`${staticDir}/nested/test.txt`, staticDir)).to.be.fulfilled;
+    await expect(validateFile(`${staticDir}/nested/../test.txt`, staticDir)).to.be.fulfilled;
   });
 
   it('should not validate file', async () => {
     // Directory
-    await expect(validateFile(staticDir, '/assets')).to.be.rejectedWith(BadRequest);
+    await expect(validateFile(`${staticDir}/`, staticDir)).to.be.rejectedWith(BadRequest);
     // File doesn't exist
-    await expect(validateFile(staticDir, '/assets/test.nope')).to.be.rejectedWith(NotFound);
-    // Wrong directory
-    await expect(validateFile(staticDir, '/')).to.be.rejectedWith(BadRequest);
+    await expect(validateFile(`${staticDir}/test.nope`, staticDir)).to.be.rejectedWith(NotFound);
     // Nested directory
-    await expect(validateFile(staticDir, '/assets/nested')).to.be.rejectedWith(BadRequest);
+    await expect(validateFile(`${staticDir}/nested`, staticDir)).to.be.rejectedWith(BadRequest);
     // Relative path to directory
-    await expect(validateFile(staticDir, '/assets/../')).to.be.rejectedWith(BadRequest);
+    await expect(validateFile(`${staticDir}/../`, staticDir)).to.be.rejectedWith(BadRequest);
     // Relative path to missing file
-    await expect(validateFile(staticDir, '/assets/../util.ts')).to.be.rejectedWith(BadRequest);
+    await expect(validateFile(`${staticDir}/../util.ts`, staticDir)).to.be.rejectedWith(BadRequest);
   });
 });
 


### PR DESCRIPTION
Add support for allowing the path to the static assets in the request to be different than the static folder on the server. See the README for a specific example.

Verified with tests and a simple app based on the example in the README.